### PR TITLE
RHOAIENG-2620: Fix single-valued metrics being wrapped into arrays in request listings (#500)

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/reconcilable/ReconcilableFeature.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/reconcilable/ReconcilableFeature.java
@@ -1,7 +1,5 @@
 package org.kie.trustyai.service.payloads.values.reconcilable;
 
-import java.util.List;
-
 import org.kie.trustyai.service.payloads.values.reconcilable.deserializers.ReconcilableFeatureDeserializer;
 import org.kie.trustyai.service.payloads.values.reconcilable.serializers.ReconcilableFieldSerializer;
 
@@ -16,7 +14,7 @@ public class ReconcilableFeature extends ReconcilableField {
         super(rawValueNode);
     }
 
-    public ReconcilableFeature(List<ValueNode> rawValueNode) {
-        super(rawValueNode);
-    }
+    //    public ReconcilableFeature(List<ValueNode> rawValueNode) {
+    //        super(rawValueNode);
+    //    }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/reconcilable/ReconcilableField.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/reconcilable/ReconcilableField.java
@@ -3,26 +3,49 @@ package org.kie.trustyai.service.payloads.values.reconcilable;
 import java.util.List;
 import java.util.Optional;
 
+import org.jboss.logging.Logger;
 import org.kie.trustyai.service.payloads.values.TypedValue;
 
 import com.fasterxml.jackson.databind.node.ValueNode;
 
 public abstract class ReconcilableField {
+    private static final Logger LOG = Logger.getLogger(ReconcilableField.class);
+
     private final List<ValueNode> rawValueNodes;
+    private final ValueNode rawValueNode;
     private Optional<List<TypedValue>> reconciledType;
 
     protected ReconcilableField(ValueNode rawValueNode) {
-        this.rawValueNodes = List.of(rawValueNode);
+        this.rawValueNode = rawValueNode;
+        this.rawValueNodes = null;
         this.reconciledType = Optional.empty();
     }
 
-    protected ReconcilableField(List<ValueNode> rawValueNode) {
-        this.rawValueNodes = rawValueNode;
-        this.reconciledType = Optional.empty();
-    }
+    // disable until better integrated with ODH UI
+    //    protected ReconcilableField(List<ValueNode> rawValueNode) {
+    //        this.rawValueNodes = rawValueNode;
+    //        this.rawValueNode = null;
+    //        this.reconciledType = Optional.empty();
+    //    }
 
     public List<ValueNode> getRawValueNodes() {
-        return rawValueNodes;
+        if (isMultipleValued()) {
+            return rawValueNodes;
+        } else {
+            return List.of(rawValueNode);
+        }
+    }
+
+    public ValueNode getRawValueNode() {
+        if (!isMultipleValued()) {
+            return rawValueNode;
+        } else {
+            throw new IllegalArgumentException("Cannot return single value of multiple-valued ReconcilableField");
+        }
+    }
+
+    public boolean isMultipleValued() {
+        return rawValueNodes != null;
     }
 
     public Optional<List<TypedValue>> getReconciledType() {
@@ -34,6 +57,10 @@ public abstract class ReconcilableField {
     }
 
     public String toString() {
-        return this.getRawValueNodes().toString();
+        if (isMultipleValued()) {
+            return rawValueNodes.toString();
+        } else {
+            return rawValueNode.toString();
+        }
     }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/reconcilable/ReconcilableOutput.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/reconcilable/ReconcilableOutput.java
@@ -1,7 +1,5 @@
 package org.kie.trustyai.service.payloads.values.reconcilable;
 
-import java.util.List;
-
 import org.kie.trustyai.service.payloads.values.reconcilable.deserializers.ReconcilableOutputDeserializer;
 import org.kie.trustyai.service.payloads.values.reconcilable.serializers.ReconcilableFieldSerializer;
 
@@ -16,7 +14,7 @@ public class ReconcilableOutput extends ReconcilableField {
         super(rawValueNode);
     }
 
-    public ReconcilableOutput(List<ValueNode> rawValueNode) {
-        super(rawValueNode);
-    }
+    //    public ReconcilableOutput(List<ValueNode> rawValueNode) {
+    //        super(rawValueNode);
+    //    }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/reconcilable/deserializers/ReconcilableFeatureDeserializer.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/reconcilable/deserializers/ReconcilableFeatureDeserializer.java
@@ -32,14 +32,15 @@ public class ReconcilableFeatureDeserializer extends StdDeserializer<Reconcilabl
         if (value.isValueNode()) {
             return new ReconcilableFeature((ValueNode) value);
         } else {
-            List<ValueNode> valueNodes = new ArrayList<>();
-            for (JsonNode subNode : value) {
-                valueNodes.add((ValueNode) subNode);
-            }
-            if (valueNodes.isEmpty()) {
-                throw new IllegalArgumentException("Passed list of feature values cannot be empty.");
-            }
-            return new ReconcilableFeature(valueNodes);
+            throw new IllegalArgumentException("Only single-valued features are allowed currently.");
+            //            List<ValueNode> valueNodes = new ArrayList<>();
+            //            for (JsonNode subNode : value) {
+            //                valueNodes.add((ValueNode) subNode);
+            //            }
+            //            if (valueNodes.isEmpty()) {
+            //                throw new IllegalArgumentException("Passed list of feature values cannot be empty.");
+            //            }
+            //            return new ReconcilableFeature(valueNodes);
         }
     }
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/reconcilable/deserializers/ReconcilableOutputDeserializer.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/reconcilable/deserializers/ReconcilableOutputDeserializer.java
@@ -32,14 +32,16 @@ public class ReconcilableOutputDeserializer extends StdDeserializer<Reconcilable
         if (value.isValueNode()) {
             return new ReconcilableOutput((ValueNode) value);
         } else {
-            List<ValueNode> valueNodes = new ArrayList<>();
-            for (JsonNode subNode : value) {
-                valueNodes.add((ValueNode) subNode);
-            }
-            if (valueNodes.isEmpty()) {
-                throw new IllegalArgumentException("Passed list of output values cannot be empty.");
-            }
-            return new ReconcilableOutput(valueNodes);
+            throw new IllegalArgumentException("Only single valued outputs are allowed currently.");
+            //
+            //            List<ValueNode> valueNodes = new ArrayList<>();
+            //            for (JsonNode subNode : value) {
+            //                valueNodes.add((ValueNode) subNode);
+            //            }
+            //            if (valueNodes.isEmpty()) {
+            //                throw new IllegalArgumentException("Passed list of output values cannot be empty.");
+            //            }
+            //            return new ReconcilableOutput(valueNodes);
         }
     }
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/reconcilable/serializers/ReconcilableFieldSerializer.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/values/reconcilable/serializers/ReconcilableFieldSerializer.java
@@ -30,7 +30,11 @@ public class ReconcilableFieldSerializer extends StdSerializer<ReconcilableField
         } else {
             jgen.writeStringField("type", "null");
         }
-        jgen.writeObjectField("value", value.getRawValueNodes());
+        if (value.isMultipleValued()) {
+            jgen.writeObjectField("value", value.getRawValueNodes());
+        } else {
+            jgen.writeObjectField("value", value.getRawValueNode());
+        }
         jgen.writeEndObject();
 
     }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/RequestPayloadGenerator.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/RequestPayloadGenerator.java
@@ -1,8 +1,6 @@
 package org.kie.trustyai.service.endpoints.metrics;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.kie.trustyai.service.payloads.metrics.fairness.group.GroupMetricRequest;
@@ -13,7 +11,6 @@ import org.kie.trustyai.service.payloads.values.reconcilable.ReconcilableOutput;
 import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import com.fasterxml.jackson.databind.node.ValueNode;
 
 public class RequestPayloadGenerator {
 
@@ -31,48 +28,49 @@ public class RequestPayloadGenerator {
         return request;
     }
 
-    public static GroupMetricRequest multiValueCorrect() {
-        GroupMetricRequest request = new GroupMetricRequest();
-        request.setProtectedAttribute("age");
-
-        List<ValueNode> privAge = new ArrayList<>();
-        List<ValueNode> unprivAge = new ArrayList<>();
-        for (int i = 0; i < 50; i++) {
-            privAge.add(IntNode.valueOf(i));
-            unprivAge.add(IntNode.valueOf(i + 50));
-        }
-        request.setFavorableOutcome(new ReconcilableOutput(IntNode.valueOf(0)));
-        request.setOutcomeName("income");
-        request.setPrivilegedAttribute(new ReconcilableFeature(privAge));
-        request.setUnprivilegedAttribute(new ReconcilableFeature(unprivAge));
-        request.setModelId(MODEL_ID);
-
-        return request;
-    }
-
-    public static GroupMetricRequest multiValueMismatchingType() {
-        GroupMetricRequest request = new GroupMetricRequest();
-        request.setProtectedAttribute("age");
-
-        List<ValueNode> privAge = new ArrayList<>();
-        List<ValueNode> unprivAge = new ArrayList<>();
-        for (int i = 0; i < 50; i++) {
-            if (i < 25) {
-                privAge.add(IntNode.valueOf(i));
-                unprivAge.add(IntNode.valueOf(i + 50));
-            } else {
-                privAge.add(TextNode.valueOf("wrong"));
-                unprivAge.add(TextNode.valueOf("wrong"));
-            }
-        }
-        request.setFavorableOutcome(new ReconcilableOutput(IntNode.valueOf(0)));
-        request.setOutcomeName("income");
-        request.setPrivilegedAttribute(new ReconcilableFeature(privAge));
-        request.setUnprivilegedAttribute(new ReconcilableFeature(unprivAge));
-        request.setModelId(MODEL_ID);
-
-        return request;
-    }
+    // multi valued requests disabled until better integrated with ODH UI
+    //    public static GroupMetricRequest multiValueCorrect() {
+    //        GroupMetricRequest request = new GroupMetricRequest();
+    //        request.setProtectedAttribute("age");
+    //
+    //        List<ValueNode> privAge = new ArrayList<>();
+    //        List<ValueNode> unprivAge = new ArrayList<>();
+    //        for (int i = 0; i < 50; i++) {
+    //            privAge.add(IntNode.valueOf(i));
+    //            unprivAge.add(IntNode.valueOf(i + 50));
+    //        }
+    //        request.setFavorableOutcome(new ReconcilableOutput(IntNode.valueOf(0)));
+    //        request.setOutcomeName("income");
+    //        request.setPrivilegedAttribute(new ReconcilableFeature(privAge));
+    //        request.setUnprivilegedAttribute(new ReconcilableFeature(unprivAge));
+    //        request.setModelId(MODEL_ID);
+    //
+    //        return request;
+    //    }
+    //
+    //    public static GroupMetricRequest multiValueMismatchingType() {
+    //        GroupMetricRequest request = new GroupMetricRequest();
+    //        request.setProtectedAttribute("age");
+    //
+    //        List<ValueNode> privAge = new ArrayList<>();
+    //        List<ValueNode> unprivAge = new ArrayList<>();
+    //        for (int i = 0; i < 50; i++) {
+    //            if (i < 25) {
+    //                privAge.add(IntNode.valueOf(i));
+    //                unprivAge.add(IntNode.valueOf(i + 50));
+    //            } else {
+    //                privAge.add(TextNode.valueOf("wrong"));
+    //                unprivAge.add(TextNode.valueOf("wrong"));
+    //            }
+    //        }
+    //        request.setFavorableOutcome(new ReconcilableOutput(IntNode.valueOf(0)));
+    //        request.setOutcomeName("income");
+    //        request.setPrivilegedAttribute(new ReconcilableFeature(privAge));
+    //        request.setUnprivilegedAttribute(new ReconcilableFeature(unprivAge));
+    //        request.setModelId(MODEL_ID);
+    //
+    //        return request;
+    //    }
 
     public static GroupMetricRequest named(String name) {
         GroupMetricRequest request = new GroupMetricRequest();

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/UniversalListingEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/UniversalListingEndpointTest.java
@@ -85,11 +85,13 @@ class UniversalListingEndpointTest {
 
         ScheduleList scheduleList = given()
                 .when()
-                .get("/metrics/all/requests")
+                .get("/metrics/all/requests").peek()
                 .then().statusCode(200).extract().body().as(ScheduleList.class);
         for (ScheduleRequest sr : scheduleList.requests) {
             if (sr.id.equals(first)) {
                 assertEquals("DIR", sr.request.getMetricName());
+                GroupMetricRequest gmr = (GroupMetricRequest) sr.request;
+                assertFalse(gmr.privilegedAttribute.isMultipleValued());
             } else if (sr.id.equals(second)) {
                 assertEquals("SPD", sr.request.getMetricName());
             } else {

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/metrics/fairness/group/DisparateImpactRatioEndpointTest.java
@@ -98,38 +98,39 @@ class DisparateImpactRatioEndpointTest {
         assertFalse(Double.isNaN(response.getValue()));
     }
 
-    @Test
-    void postMultiValueCorrect() throws JsonProcessingException {
-        datasource.get().reset();
-
-        final GroupMetricRequest payload = RequestPayloadGenerator.multiValueCorrect();
-
-        final BaseMetricResponse response = given()
-                .contentType(ContentType.JSON)
-                .body(payload)
-                .when().post()
-                .then().statusCode(Response.Status.OK.getStatusCode())
-                .extract()
-                .body().as(BaseMetricResponse.class);
-
-        assertEquals("metric", response.getType());
-        assertEquals("DIR", response.getName());
-        assertFalse(Double.isNaN(response.getValue()));
-    }
-
-    @Test
-    void postMultiValueMismatchingType() throws JsonProcessingException {
-        datasource.get().reset();
-
-        final GroupMetricRequest payload = RequestPayloadGenerator.multiValueMismatchingType();
-
-        given()
-                .contentType(ContentType.JSON)
-                .body(payload)
-                .when().post()
-                .then().statusCode(Response.Status.BAD_REQUEST.getStatusCode())
-                .body(containsString("Received invalid type for privileged attribute=age: got 'wrong', expected object compatible with 'INT32'"));
-    }
+    // disabled until better integrated with ODH UI
+    //    @Test
+    //    void postMultiValueCorrect() throws JsonProcessingException {
+    //        datasource.get().reset();
+    //
+    //        final GroupMetricRequest payload = RequestPayloadGenerator.multiValueCorrect();
+    //
+    //        final BaseMetricResponse response = given()
+    //                .contentType(ContentType.JSON)
+    //                .body(payload)
+    //                .when().post()
+    //                .then().statusCode(Response.Status.OK.getStatusCode())
+    //                .extract()
+    //                .body().as(BaseMetricResponse.class);
+    //
+    //        assertEquals("metric", response.getType());
+    //        assertEquals("DIR", response.getName());
+    //        assertFalse(Double.isNaN(response.getValue()));
+    //    }
+    //
+    //    @Test
+    //    void postMultiValueMismatchingType() throws JsonProcessingException {
+    //        datasource.get().reset();
+    //
+    //        final GroupMetricRequest payload = RequestPayloadGenerator.multiValueMismatchingType();
+    //
+    //        given()
+    //                .contentType(ContentType.JSON)
+    //                .body(payload)
+    //                .when().post()
+    //                .then().statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+    //                .body(containsString("Received invalid type for privileged attribute=age: got 'wrong', expected object compatible with 'INT32'"));
+    //    }
 
     @Test
     void postThresh() throws JsonProcessingException {


### PR DESCRIPTION

* Fix single-valued metrics being wrapped into arrays in request listing endpoints

* Remove multi-valued bias metric ingestion for now

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

