### PR TITLE
fix(cherry-pick): Disable explainability endpoints (#615)

### DIFF
--- a/explainability-service/src/main/resources/application.properties
+++ b/explainability-service/src/main/resources/application.properties
@@ -99,8 +99,8 @@ quarkus.hibernate-orm.jdbc.statement-batch-size=50
 # rhoai endpoints
 %rhoai.endpoints.fairness=disable
 %rhoai.endpoints.drift=enable
-%rhoai.endpoints.explainers.local.shap=enable
-%rhoai.endpoints.explainers.local.lime=enable
+%rhoai.endpoints.explainers.local.shap=disable
+%rhoai.endpoints.explainers.local.lime=disable
 %rhoai.endpoints.explainers.local.counterfactual=disable
 %rhoai.endpoints.explainers.local.tssaliency=disable
 %rhoai.endpoints.explainers.global=disable


### PR DESCRIPTION
(cherry picked from commit 24d3237cbc04297c4bd404c9d77f22c586f0a7fd)
