### PR TITLE
fix(cherry-pick): Lengthen longest storable partial payload, add too-long payload error messages (#616)

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/data/exceptions/PayloadWriteException.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/data/exceptions/PayloadWriteException.java
@@ -1,0 +1,7 @@
+package org.kie.trustyai.service.data.exceptions;
+
+public class PayloadWriteException extends RuntimeException {
+    public PayloadWriteException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpoint.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/ConsumerEndpoint.java
@@ -6,6 +6,7 @@ import org.jboss.logging.Logger;
 import org.kie.trustyai.service.data.datasources.DataSource;
 import org.kie.trustyai.service.data.exceptions.DataframeCreateException;
 import org.kie.trustyai.service.data.exceptions.InvalidSchemaException;
+import org.kie.trustyai.service.data.exceptions.PayloadWriteException;
 import org.kie.trustyai.service.data.exceptions.StorageWriteException;
 import org.kie.trustyai.service.data.reconcilers.ModelMeshInferencePayloadReconciler;
 import org.kie.trustyai.service.payloads.consumer.partial.InferencePartialPayload;
@@ -45,6 +46,10 @@ public class ConsumerEndpoint {
                 final String message = "Error when reconciling payload for request id='" + request.getId() + "': " + e.getMessage();
                 LOG.error(message);
                 return Response.serverError().entity(message).status(Response.Status.BAD_REQUEST).build();
+            } catch (PayloadWriteException e) {
+                final String message = e.getMessage();
+                LOG.error(message);
+                return Response.serverError().entity(message).status(Response.Status.BAD_REQUEST).build();
             }
         } else if (request.getKind().equals(PartialKind.response)) {
             LOG.info("Received partial output payload from model='" + request.getModelId() + "', id=" + request.getId());
@@ -52,6 +57,10 @@ public class ConsumerEndpoint {
                 reconciler.addUnreconciledOutput(request);
             } catch (InvalidSchemaException | DataframeCreateException | StorageWriteException e) {
                 final String message = "Error when reconciling payload for response id='" + request.getId() + "': " + e.getMessage();
+                LOG.error(message);
+                return Response.serverError().entity(message).status(Response.Status.BAD_REQUEST).build();
+            } catch (PayloadWriteException e) {
+                final String message = e.getMessage();
                 LOG.error(message);
                 return Response.serverError().entity(message).status(Response.Status.BAD_REQUEST).build();
             }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/partial/InferencePartialPayload.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/consumer/partial/InferencePartialPayload.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Lob;
 
 @Entity
 public class InferencePartialPayload extends PartialPayload {
-    @Column(columnDefinition = "text")
+    // mariadb specific?
+    @Lob
+    @Column(length = 32_000_000)
     private String data;
 
     @JsonProperty("modelid")

--- a/explainability-service/src/test/java/org/kie/trustyai/service/PayloadProducer.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/PayloadProducer.java
@@ -66,6 +66,15 @@ public class PayloadProducer {
         return payload;
     }
 
+    public static InferencePartialPayload getInferencePartialPayloadInput(String id, int number, int repeats) {
+        final InferencePartialPayload payload = new InferencePartialPayload();
+        payload.setData(encondedInputPayloadsA[number].repeat(repeats));
+        payload.setId(id);
+        payload.setKind(PartialKind.request);
+        payload.setModelId(MODEL_A_ID);
+        return payload;
+    }
+
     public static InferencePartialPayload getInferencePartialPayloadOutput(String id, int number) {
         final InferencePartialPayload payload = new InferencePartialPayload();
         payload.setData(encondedOutputPayloadsA[number]);

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/base/ConsumerEndpointBaseTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/base/ConsumerEndpointBaseTest.java
@@ -7,6 +7,7 @@ import java.util.stream.IntStream;
 
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.kie.trustyai.explainability.model.dataframe.Dataframe;
 import org.kie.trustyai.service.PayloadProducer;
@@ -28,6 +29,7 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -156,6 +158,21 @@ abstract class ConsumerEndpointBaseTest {
         final Dataframe dataframe = datasource.get().getDataframe(MODEL_A_ID);
         assertEquals(5, dataframe.getRowDimension());
 
+    }
+
+    @Test
+    @Disabled("This failure case is only relevant for MariaDB testing")
+    void consumePartialPostHuge() {
+
+        // this should fail
+        final InferencePartialPayload payload2 = PayloadProducer.getInferencePartialPayloadInput(UUID.randomUUID().toString(), 0, 25_000);
+        given()
+                .contentType(ContentType.JSON)
+                .body(payload2)
+                .when().post()
+                .then()
+                .statusCode(RestResponse.StatusCode.BAD_REQUEST)
+                .body(containsString("This can happen if the payload is too large, try reducing inference batch size."));
     }
 
     @Test


### PR DESCRIPTION


* Lengthen longest payload that is storable, add error catching for too-long partial payloads

* Update InferencePartialPayload.java

(cherry picked from commit 82e40d60a4f7b5c67fdf05e74b9c5e9ea423b6cd)
