### PR TITLE
RHOAIENG-13434: Update io-grpc from 1.59 to 1.68

### DIFF
--- a/explainability-connectors/pom.xml
+++ b/explainability-connectors/pom.xml
@@ -23,6 +23,7 @@
     <dependencyManagement>
         <dependencies>
             <!-- Override the version of protobuf-java until io-grpc moves from 3.25.3 to 3.25.5-->
+            <!-- Refer to https://issues.redhat.com/browse/RHOAIENG-13452-->
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>

--- a/explainability-connectors/pom.xml
+++ b/explainability-connectors/pom.xml
@@ -16,9 +16,21 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <grpc.version>1.59.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
+        <grpc.version>1.68.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
         <protoc.version>3.19.3</protoc.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Override the version of protobuf-java until io-grpc moves from 3.25.3 to 3.25.5-->
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>3.25.5</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.kie.trustyai</groupId>

--- a/explainability-service/pom.xml
+++ b/explainability-service/pom.xml
@@ -33,6 +33,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Override the version of protobuf-java until io-grpc moves from 3.25.3 to 3.25.5-->
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>3.25.5</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/explainability-service/pom.xml
+++ b/explainability-service/pom.xml
@@ -34,6 +34,7 @@
                 <scope>import</scope>
             </dependency>
             <!-- Override the version of protobuf-java until io-grpc moves from 3.25.3 to 3.25.5-->
+            <!-- Refer to https://issues.redhat.com/browse/RHOAIENG-13452-->
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>


### PR DESCRIPTION
Refers to [RHOAIENG-13434](https://issues.redhat.com/browse/RHOAIENG-13434).

com.google.protobuf:protobuf-java has to be manually overriden with 3.25.5, since io-grpc 1.68 still uses 3.25.3.

This override can be removed once a io-grpc version uses com.google.protobuf:protobuf-java >= 3.25.5

