### PR TITLE
RHOAIENG-13436: Update io-grpc from 1.59 to 1.68

### DIFF
--- a/explainability-connectors/pom.xml
+++ b/explainability-connectors/pom.xml
@@ -16,9 +16,21 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <grpc.version>1.65.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
+        <grpc.version>1.68.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
         <protoc.version>3.19.3</protoc.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Override the version of protobuf-java until io-grpc moves from 3.25.3 to 3.25.5-->
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>3.25.5</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.kie.trustyai</groupId>

--- a/explainability-service/pom.xml
+++ b/explainability-service/pom.xml
@@ -32,6 +32,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+          <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.25.5</version>
+          </dependency>
         </dependencies>
     </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
Refers to [RHOAIENG-13436](https://issues.redhat.com/browse/RHOAIENG-13436).

com.google.protobuf:protobuf-java has to be manually overriden with 3.25.5, since io-grpc 1.68 still uses 3.25.3.

This override can be removed once a io-grpc version uses com.google.protobuf:protobuf-java >= 3.25.5