### PR TITLE
fix(RHOAIENG-32175): Upgrade io.netty versions to 4.1.124.Final (2.8)

### DIFF
--- a/explainability-arrow/pom.xml
+++ b/explainability-arrow/pom.xml
@@ -13,8 +13,7 @@
     <name>TrustyAI Arrow</name>
 
     <properties>
-        <version.org.apache.arrow>14.0.1</version.org.apache.arrow>
-        <version.io.netty>4.1.68.Final</version.io.netty>
+        <version.org.apache.arrow>18.3.0</version.org.apache.arrow>
         <version.com.google.flatbuffers>2.0.3</version.com.google.flatbuffers>
         <version.com.fasterxml.jackson.core>2.15.0
         </version.com.fasterxml.jackson.core> <!-- sync this with the databind version -->

--- a/explainability-service/pom.xml
+++ b/explainability-service/pom.xml
@@ -40,6 +40,23 @@
                 <artifactId>protobuf-java</artifactId>
                 <version>3.25.5</version>
             </dependency>
+            
+            <!-- Override gRPC version to ensure consistent Netty usage -->
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-netty-shaded</artifactId>
+                <version>1.68.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-protobuf</artifactId>
+                <version>1.68.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-stub</artifactId>
+                <version>1.68.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <version.org.mockito>4.8.0</version.org.mockito>
         <version.org.assertj>3.22.0</version.org.assertj>
         <version.org.awaitility>4.2.0</version.org.awaitility>
+        <version.io.netty>4.1.124.Final</version.io.netty>
 
         <version.org.optaplanner>8.30.0.Final</version.org.optaplanner>
         <version.org.kie.kogito>1.30.0.Final</version.org.kie.kogito>
@@ -154,6 +155,83 @@
                 <groupId>org.apache.opennlp</groupId>
                 <artifactId>opennlp-tools</artifactId>
                 <version>${version.org.apache.opennlp}</version>
+            </dependency>
+
+            <!-- Netty dependency management to override all transitive versions -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+                <version>${version.io.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-buffer</artifactId>
+                <version>${version.io.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+                <version>${version.io.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>${version.io.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>${version.io.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-socks</artifactId>
+                <version>${version.io.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-dns</artifactId>
+                <version>${version.io.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-common</artifactId>
+                <version>${version.io.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${version.io.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler-proxy</artifactId>
+                <version>${version.io.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-resolver</artifactId>
+                <version>${version.io.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-resolver-dns</artifactId>
+                <version>${version.io.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport</artifactId>
+                <version>${version.io.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-unix-common</artifactId>
+                <version>${version.io.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-haproxy</artifactId>
+                <version>${version.io.netty}</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
Also updated Apache Arrow to 18.3.0, since previous version was not compatible with Netty 4.1.124.Final.

Refer to [RHOAIENG-32175](https://issues.redhat.com/browse/RHOAIENG-32175).
