### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-trustyai-service-v2-22

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -42,7 +42,8 @@ ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.zutil.logging.manager=org.jbos
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
 LABEL com.redhat.component="odh-trustyai-service" \
-      name="managed-open-data-hub/odh-trustyai-service-rhel8" \
+      name="rhoai/odh-trustyai-service-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.22::el9" \
       description="TrustyAI is a service to provide integration fairness and bias tracking to modelmesh-served models" \
       summary="odh-trustyai-service" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
