### PR TITLE
fix: Add gzip decompression filter for KServe agent uploads

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/GzipRequestFilter.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/GzipRequestFilter.java
@@ -1,0 +1,102 @@
+package org.kie.trustyai.service.endpoints.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
+
+import org.jboss.logging.Logger;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * JAX-RS filter that automatically decompresses gzip-encoded request bodies for data upload endpoints.
+ *
+ * This filter is scoped to the /data/upload endpoint to avoid unexpected behavior for other consumers.
+ * It checks for the "Content-Encoding: gzip" header and transparently decompresses the request body
+ * before it reaches the endpoint handlers.
+ *
+ * This is necessary because the KServe agent sidecar automatically gzip-compresses CloudEvent
+ * payloads when logging to TrustyAI in RawDeployment mode.
+ *
+ * The filter handles multiple/stacked encodings (e.g., "gzip, br") by:
+ * 1. Detecting if "gzip" is present in the Content-Encoding header
+ * 2. Decompressing the gzip layer
+ * 3. Removing only "gzip" from the header, preserving other encodings for downstream processing
+ *
+ * If decompression fails, returns HTTP 400 (Bad Request) with a clear error message rather than
+ * allowing the IOException to surface as a generic 500 error.
+ */
+@Provider
+@Priority(Priorities.HEADER_DECORATOR)
+public class GzipRequestFilter implements ContainerRequestFilter {
+
+    private static final Logger LOG = Logger.getLogger(GzipRequestFilter.class);
+    private static final String CONTENT_ENCODING = "Content-Encoding";
+    private static final String GZIP = "gzip";
+    private static final String DATA_UPLOAD_PATH = "/data/upload";
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        String path = requestContext.getUriInfo().getPath();
+        String contentEncoding = requestContext.getHeaderString(CONTENT_ENCODING);
+
+        // Only apply filter to /data/upload endpoint to avoid unexpected behavior for other consumers
+        if (!path.endsWith(DATA_UPLOAD_PATH)) {
+            return;
+        }
+
+        // Support multiple/stacked encodings (e.g., "gzip, br") by checking if gzip is present
+        if (contentEncoding != null && contentEncoding.toLowerCase(Locale.ROOT).contains(GZIP)) {
+            LOG.debugf("Decompressing gzip-encoded request body for path: %s", path);
+
+            try {
+                InputStream originalStream = requestContext.getEntityStream();
+                GZIPInputStream gzipStream = new GZIPInputStream(originalStream);
+                requestContext.setEntityStream(gzipStream);
+
+                // Remove only "gzip" from Content-Encoding, preserving other encodings for downstream processing
+                updateContentEncoding(requestContext, contentEncoding);
+
+                LOG.debugf("Successfully decompressed gzip request for path: %s", path);
+            } catch (IOException e) {
+                LOG.errorf(e, "Failed to decompress gzip-encoded request body for path: %s", path);
+
+                // Return 400 Bad Request with clear message instead of letting it surface as 500
+                Response response = Response.status(Response.Status.BAD_REQUEST)
+                        .type(MediaType.TEXT_PLAIN_TYPE)
+                        .entity("Request body could not be decompressed as gzip: invalid or corrupted content.")
+                        .build();
+
+                requestContext.abortWith(response);
+            }
+        }
+    }
+
+    /**
+     * Removes "gzip" from the Content-Encoding header while preserving other encodings.
+     * For example: "gzip, br" becomes "br", and "gzip" is removed entirely.
+     */
+    private void updateContentEncoding(ContainerRequestContext requestContext, String contentEncoding) {
+        String remainingEncodings = Arrays.stream(contentEncoding.split(","))
+                .map(String::trim)
+                .filter(encoding -> !encoding.equalsIgnoreCase(GZIP))
+                .collect(Collectors.joining(", "));
+
+        if (remainingEncodings.isEmpty()) {
+            // No other encodings remain, remove the header entirely
+            requestContext.getHeaders().remove(CONTENT_ENCODING);
+        } else {
+            // Update header with remaining encodings
+            requestContext.getHeaders().putSingle(CONTENT_ENCODING, remainingEncodings);
+        }
+    }
+}

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/UploadEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/UploadEndpointTest.java
@@ -1,6 +1,9 @@
 package org.kie.trustyai.service.endpoints.data;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.zip.GZIPOutputStream;
 
 import org.jboss.resteasy.reactive.RestResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,11 +12,11 @@ import org.kie.trustyai.explainability.model.dataframe.Dataframe;
 import org.kie.trustyai.service.mocks.flatfile.MockCSVDatasource;
 import org.kie.trustyai.service.mocks.flatfile.MockMemoryStorage;
 import org.kie.trustyai.service.payloads.data.upload.ModelInferJointPayload;
-import org.kie.trustyai.service.payloads.data.upload.ModelInferRequestPayload;
 import org.kie.trustyai.service.profiles.flatfile.MemoryTestProfile;
 import org.kie.trustyai.service.utils.KserveRestPayloads;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
@@ -309,7 +312,7 @@ class UploadEndpointTest {
     }
 
     @Test
-    void uploadGaussianData(){
+    void uploadGaussianData() {
         String payload = """
                 {
                   "model_name": "gaussian-credit-model",
@@ -363,5 +366,58 @@ class UploadEndpointTest {
                 .statusCode(RestResponse.StatusCode.OK)
                 .body(containsString("2 datapoints"));
 
+    }
+
+    @Test
+    void uploadGzipCompressedData() throws Exception {
+        // Test that gzip-compressed payloads are handled correctly
+        // This simulates KServe agent behavior in RawDeployment mode
+        ModelInferJointPayload payload = KserveRestPayloads.generatePayload(5, 2, 1, "INT64", "COMPRESSED_TEST");
+
+        // Serialize payload to JSON
+        ObjectMapper objectMapper = new ObjectMapper();
+        byte[] jsonBytes = objectMapper.writeValueAsBytes(payload);
+
+        // Compress with gzip
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzipStream = new GZIPOutputStream(byteStream)) {
+            gzipStream.write(jsonBytes);
+        }
+        byte[] gzipBytes = byteStream.toByteArray();
+
+        emptyStorage();
+
+        // Send gzip-compressed request
+        given()
+                .contentType(ContentType.JSON)
+                .header("Content-Encoding", "gzip")
+                .body(gzipBytes)
+                .when().post("/upload")
+                .then()
+                .statusCode(RestResponse.StatusCode.OK)
+                .body(containsString("5 datapoints"));
+
+        // Verify data was stored correctly
+        Dataframe df = datasource.get().getDataframe(payload.getModelName());
+        assertEquals(5, df.getRowDimension());
+        assertEquals(3, df.getColumnDimension()); // 2 inputs + 1 output
+
+        emptyStorage();
+    }
+
+    @Test
+    void uploadMalformedGzipCompressedData() {
+        // Test that malformed gzip-compressed payloads return a client error (400)
+        // rather than a server error (500)
+        byte[] invalidGzipPayload = "not-a-valid-gzip-stream".getBytes(StandardCharsets.UTF_8);
+
+        given()
+                .contentType(ContentType.JSON)
+                .header("Content-Encoding", "gzip")
+                .body(invalidGzipPayload)
+                .when().post("/upload")
+                .then()
+                .statusCode(RestResponse.StatusCode.BAD_REQUEST)
+                .body(containsString("could not be decompressed"));
     }
 }


### PR DESCRIPTION
## Summary

Cherry-pick of [trustyai-explainability/trustyai-explainability#704](https://github.com/trustyai-explainability/trustyai-explainability/pull/704) to `rhoai-3.3`.

Fixes issue where KServe agent in RawDeployment mode sends gzip-compressed CloudEvent payloads that TrustyAI couldn't parse.

- **Root Cause**: KServe agent's Go `http.Transport` automatically enables gzip compression by default
- **Error**: TrustyAI received compressed payloads but attempted to parse as raw JSON
- **Result**: HTTP 400 with `JsonParseException: Unexpected character (CTRL-CHAR, code 31)` (gzip magic byte `0x1f`)
- **Scope**: Only affected RawDeployment mode (KNative's networking layer handled decompression transparently)

## Changes

- **New File**: `GzipRequestFilter.java` - JAX-RS filter for gzip decompression (scoped to `/data/upload` endpoint)
- **Modified**: `UploadEndpointTest.java` - Added `uploadGzipCompressedData()` and `uploadMalformedGzipCompressedData()` unit tests

## Testing

Unit tests passing upstream. Manual verification on OpenShift cluster confirmed fix.

## CI Note

The `HibernatePrometheusTest.deleteFairnessRequest` failure (`expected: <true> but was: <false>`) is a **pre-existing flaky test** on the `rhoai-3.3` branch, unrelated to this change. The same test fails in a [prior run on `rhoai-3.3`](https://github.com/red-hat-data-services/trustyai-explainability/actions/runs/24827970137) (April 23, before this PR existed). All gzip-related tests pass across all Maven versions.

**JIRA**: [RHOAIENG-60518](https://redhat.atlassian.net/browse/RHOAIENG-60518), [RHOAIENG-52393](https://redhat.atlassian.net/browse/RHOAIENG-52393)