### PR TITLE
Update branch patterns to cover 3.x branches

### DIFF
--- a/.github/workflows/trigger-pnc-build.yaml
+++ b/.github/workflows/trigger-pnc-build.yaml
@@ -4,8 +4,10 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'rhoai-2.1[6-9]+'
-      - 'rhoai-2.[2-9][0-9]' # Trigger the workflow on pushes to any rhoai-2.20 to rhoai-2.99 branch
+      - 'rhoai-[23].[0-9]'  # e.g. rhoai-2.1, rhoai-3.1, rhoai-3.4
+      - 'rhoai-[23].[0-9][0-9]'  # e.g. rhoai-2.10, rhoai-3.10, rhoai-3.22
+      - 'rhoai-[3].[0-9]-ea.[0-9]'  # e.g. rhoai-3.4-ea.1, rhoai-3.5-ea.2
+      - 'rhoai-[3].[0-9][0-9]-ea.[0-9]'  # e.g. rhoai-3.10-ea.3
     paths-ignore:
       - .tekton/**
       - .github/**


### PR DESCRIPTION
Cherry-pick of #1198 to `rhoai-3.3`.

## Summary
- Update branch glob patterns in `trigger-pnc-build.yaml` to cover `rhoai-3.x` and `rhoai-3.x-ea.x` branches in addition to existing `rhoai-2.x` branches.

🍒 Cherry-picked from commit 87b652b7