### PR TITLE
sync: Upstream main → rhoai-3.5-ea.2

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/CloudEventConsumer.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/CloudEventConsumer.java
@@ -35,10 +35,17 @@ public class CloudEventConsumer {
     @CloudEventMapping(trigger = "org.kubeflow.serving.inference.request")
     public void consumeKubeflowRequest(CloudEvent<byte[]> cloudEvent) {
         LOG.debug("Received Kubeflow request with id = " + cloudEvent.id());
+        byte[] data;
+        try {
+            data = cloudEvent.data();
+        } catch (NullPointerException e) {
+            LOG.warn("CloudEvent request has no data payload, skipping id=" + cloudEvent.id());
+            return;
+        }
         final KServeInputPayload input = new KServeInputPayload();
         input.setId(cloudEvent.id());
         input.setModelId(cloudEvent.extensions().get("Inferenceservicename"));
-        input.setData(new String(decompressIfGzip(cloudEvent.data()), StandardCharsets.UTF_8));
+        input.setData(new String(decompressIfGzip(data), StandardCharsets.UTF_8));
         reconciler.addUnreconciledInput(input);
     }
 
@@ -46,17 +53,24 @@ public class CloudEventConsumer {
     @CloudEventMapping(trigger = "org.kubeflow.serving.inference.response")
     public void consumeKubeflowResponse(CloudEvent<byte[]> cloudEvent) throws JsonProcessingException {
         LOG.debug("Received Kubeflow response with id = " + cloudEvent.id());
+        byte[] data;
+        try {
+            data = cloudEvent.data();
+        } catch (NullPointerException e) {
+            LOG.warn("CloudEvent response has no data payload, skipping id=" + cloudEvent.id());
+            return;
+        }
 
         final KServeOutputPayload output = new KServeOutputPayload();
         output.setId(cloudEvent.id());
         output.setModelId(cloudEvent.extensions().get("Inferenceservicename"));
-        byte[] original = decompressIfGzip(cloudEvent.data());
+        byte[] original = decompressIfGzip(data);
         String decoded = new String(original, StandardCharsets.UTF_8);
 
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        InferenceLoggerOutput data = objectMapper.readValue(decoded, InferenceLoggerOutput.class);
-        output.setData(data);
+        InferenceLoggerOutput loggerOutput = objectMapper.readValue(decoded, InferenceLoggerOutput.class);
+        output.setData(loggerOutput);
         reconciler.addUnreconciledOutput(output);
     }
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/CloudEventConsumer.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/CloudEventConsumer.java
@@ -1,6 +1,10 @@
 package org.kie.trustyai.service.endpoints.consumer;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
 
 import org.jboss.logging.Logger;
 import org.kie.trustyai.service.data.reconcilers.KServeInferencePayloadReconciler;
@@ -34,7 +38,7 @@ public class CloudEventConsumer {
         final KServeInputPayload input = new KServeInputPayload();
         input.setId(cloudEvent.id());
         input.setModelId(cloudEvent.extensions().get("Inferenceservicename"));
-        input.setData(new String(cloudEvent.data(), StandardCharsets.UTF_8));
+        input.setData(new String(decompressIfGzip(cloudEvent.data()), StandardCharsets.UTF_8));
         reconciler.addUnreconciledInput(input);
     }
 
@@ -46,7 +50,7 @@ public class CloudEventConsumer {
         final KServeOutputPayload output = new KServeOutputPayload();
         output.setId(cloudEvent.id());
         output.setModelId(cloudEvent.extensions().get("Inferenceservicename"));
-        byte[] original = cloudEvent.data();
+        byte[] original = decompressIfGzip(cloudEvent.data());
         String decoded = new String(original, StandardCharsets.UTF_8);
 
         ObjectMapper objectMapper = new ObjectMapper();
@@ -54,5 +58,29 @@ public class CloudEventConsumer {
         InferenceLoggerOutput data = objectMapper.readValue(decoded, InferenceLoggerOutput.class);
         output.setData(data);
         reconciler.addUnreconciledOutput(output);
+    }
+
+    static final int MAX_DECOMPRESSED_SIZE = 100 * 1024 * 1024; // 100 MB
+
+    static byte[] decompressIfGzip(byte[] data) {
+        if (data == null || data.length < 2 || (data[0] & 0xFF) != 0x1F || (data[1] & 0xFF) != 0x8B) {
+            return data != null ? data : new byte[0];
+        }
+        try (GZIPInputStream gis = new GZIPInputStream(new ByteArrayInputStream(data));
+                ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[8192];
+            int len;
+            while ((len = gis.read(buffer)) != -1) {
+                bos.write(buffer, 0, len);
+                if (bos.size() > MAX_DECOMPRESSED_SIZE) {
+                    throw new IOException("Decompressed payload exceeds " + MAX_DECOMPRESSED_SIZE + " bytes");
+                }
+            }
+            LOG.debug("Decompressed gzip CloudEvent payload");
+            return bos.toByteArray();
+        } catch (IOException e) {
+            LOG.warn("CloudEvent payload starts with gzip magic bytes but failed to decompress, using raw bytes", e);
+            return data;
+        }
     }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/GzipRequestFilter.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/service/GzipRequestFilter.java
@@ -1,102 +1,56 @@
 package org.kie.trustyai.service.endpoints.service;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
 import java.util.Locale;
-import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 import org.jboss.logging.Logger;
 
-import jakarta.annotation.Priority;
-import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 
-/**
- * JAX-RS filter that automatically decompresses gzip-encoded request bodies for data upload endpoints.
- *
- * This filter is scoped to the /data/upload endpoint to avoid unexpected behavior for other consumers.
- * It checks for the "Content-Encoding: gzip" header and transparently decompresses the request body
- * before it reaches the endpoint handlers.
- *
- * This is necessary because the KServe agent sidecar automatically gzip-compresses CloudEvent
- * payloads when logging to TrustyAI in RawDeployment mode.
- *
- * The filter handles multiple/stacked encodings (e.g., "gzip, br") by:
- * 1. Detecting if "gzip" is present in the Content-Encoding header
- * 2. Decompressing the gzip layer
- * 3. Removing only "gzip" from the header, preserving other encodings for downstream processing
- *
- * If decompression fails, returns HTTP 400 (Bad Request) with a clear error message rather than
- * allowing the IOException to surface as a generic 500 error.
- */
 @Provider
-@Priority(Priorities.HEADER_DECORATOR)
+@PreMatching
 public class GzipRequestFilter implements ContainerRequestFilter {
 
     private static final Logger LOG = Logger.getLogger(GzipRequestFilter.class);
-    private static final String CONTENT_ENCODING = "Content-Encoding";
-    private static final String GZIP = "gzip";
-    private static final String DATA_UPLOAD_PATH = "/data/upload";
+    static final int MAX_DECOMPRESSED_SIZE = 100 * 1024 * 1024; // 100 MB
 
     @Override
-    public void filter(ContainerRequestContext requestContext) {
-        String path = requestContext.getUriInfo().getPath();
-        String contentEncoding = requestContext.getHeaderString(CONTENT_ENCODING);
-
-        // Only apply filter to /data/upload endpoint to avoid unexpected behavior for other consumers
-        if (!path.endsWith(DATA_UPLOAD_PATH)) {
+    public void filter(ContainerRequestContext ctx) {
+        String encoding = ctx.getHeaderString("Content-Encoding");
+        if (encoding == null || !encoding.toLowerCase(Locale.ROOT).contains("gzip")) {
             return;
         }
 
-        // Support multiple/stacked encodings (e.g., "gzip, br") by checking if gzip is present
-        if (contentEncoding != null && contentEncoding.toLowerCase(Locale.ROOT).contains(GZIP)) {
-            LOG.debugf("Decompressing gzip-encoded request body for path: %s", path);
-
-            try {
-                InputStream originalStream = requestContext.getEntityStream();
-                GZIPInputStream gzipStream = new GZIPInputStream(originalStream);
-                requestContext.setEntityStream(gzipStream);
-
-                // Remove only "gzip" from Content-Encoding, preserving other encodings for downstream processing
-                updateContentEncoding(requestContext, contentEncoding);
-
-                LOG.debugf("Successfully decompressed gzip request for path: %s", path);
-            } catch (IOException e) {
-                LOG.errorf(e, "Failed to decompress gzip-encoded request body for path: %s", path);
-
-                // Return 400 Bad Request with clear message instead of letting it surface as 500
-                Response response = Response.status(Response.Status.BAD_REQUEST)
-                        .type(MediaType.TEXT_PLAIN_TYPE)
-                        .entity("Request body could not be decompressed as gzip: invalid or corrupted content.")
-                        .build();
-
-                requestContext.abortWith(response);
+        try {
+            byte[] compressed = ctx.getEntityStream().readAllBytes();
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            try (GZIPInputStream gzis = new GZIPInputStream(new ByteArrayInputStream(compressed))) {
+                byte[] buffer = new byte[8192];
+                int len;
+                while ((len = gzis.read(buffer)) != -1) {
+                    bos.write(buffer, 0, len);
+                    if (bos.size() > MAX_DECOMPRESSED_SIZE) {
+                        throw new IOException("Decompressed payload exceeds " + MAX_DECOMPRESSED_SIZE + " bytes");
+                    }
+                }
             }
-        }
-    }
-
-    /**
-     * Removes "gzip" from the Content-Encoding header while preserving other encodings.
-     * For example: "gzip, br" becomes "br", and "gzip" is removed entirely.
-     */
-    private void updateContentEncoding(ContainerRequestContext requestContext, String contentEncoding) {
-        String remainingEncodings = Arrays.stream(contentEncoding.split(","))
-                .map(String::trim)
-                .filter(encoding -> !encoding.equalsIgnoreCase(GZIP))
-                .collect(Collectors.joining(", "));
-
-        if (remainingEncodings.isEmpty()) {
-            // No other encodings remain, remove the header entirely
-            requestContext.getHeaders().remove(CONTENT_ENCODING);
-        } else {
-            // Update header with remaining encodings
-            requestContext.getHeaders().putSingle(CONTENT_ENCODING, remainingEncodings);
+            ctx.setEntityStream(new ByteArrayInputStream(bos.toByteArray()));
+            ctx.getHeaders().remove("Content-Encoding");
+            LOG.debugf("Decompressed gzip request body (%d -> %d bytes)", compressed.length, bos.size());
+        } catch (IOException e) {
+            LOG.warnf("Failed to decompress gzip request: %s", e.getMessage());
+            ctx.abortWith(Response.status(Response.Status.BAD_REQUEST)
+                    .type(MediaType.TEXT_PLAIN_TYPE)
+                    .entity("Request body could not be decompressed as gzip: invalid or corrupted content.")
+                    .build());
         }
     }
 }

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/CloudEventConsumerDecompressTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/consumer/CloudEventConsumerDecompressTest.java
@@ -1,0 +1,77 @@
+package org.kie.trustyai.service.endpoints.consumer;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.zip.GZIPOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CloudEventConsumerDecompressTest {
+
+    @Test
+    void decompressValidGzip() throws Exception {
+        byte[] original = "{\"model_name\":\"test\"}".getBytes(StandardCharsets.UTF_8);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(baos)) {
+            gzip.write(original);
+        }
+
+        byte[] result = CloudEventConsumer.decompressIfGzip(baos.toByteArray());
+        assertArrayEquals(original, result);
+    }
+
+    @Test
+    void passthroughNonGzipData() {
+        byte[] plainJson = "{\"model_name\":\"test\"}".getBytes(StandardCharsets.UTF_8);
+
+        byte[] result = CloudEventConsumer.decompressIfGzip(plainJson);
+        assertArrayEquals(plainJson, result);
+    }
+
+    @Test
+    void passthroughEmptyData() {
+        byte[] empty = new byte[0];
+
+        byte[] result = CloudEventConsumer.decompressIfGzip(empty);
+        assertEquals(0, result.length);
+    }
+
+    @Test
+    void fallbackOnMalformedGzip() {
+        // Starts with gzip magic bytes but is not valid gzip
+        byte[] malformed = new byte[] { 0x1F, (byte) 0x8B, 0x00, 0x01, 0x02 };
+
+        byte[] result = CloudEventConsumer.decompressIfGzip(malformed);
+        assertArrayEquals(malformed, result);
+    }
+
+    @Test
+    void passthroughNullData() {
+        byte[] result = CloudEventConsumer.decompressIfGzip(null);
+        assertEquals(0, result.length);
+    }
+
+    @Test
+    void fallbackOnDecompressionBomb() throws Exception {
+        // Create a gzip payload that decompresses to >100MB
+        // Use a highly repetitive pattern that compresses well
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(baos)) {
+            byte[] chunk = new byte[1024 * 1024]; // 1MB of zeros
+            Arrays.fill(chunk, (byte) 0);
+            for (int i = 0; i < 101; i++) { // Write 101MB of zeros (compresses to ~100KB)
+                gzip.write(chunk);
+            }
+        }
+
+        byte[] compressedBomb = baos.toByteArray();
+
+        // Should fall back to original compressed bytes (not decompress the bomb)
+        byte[] result = CloudEventConsumer.decompressIfGzip(compressedBomb);
+        assertArrayEquals(compressedBomb, result);
+    }
+}

--- a/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/UploadEndpointTest.java
+++ b/explainability-service/src/test/java/org/kie/trustyai/service/endpoints/data/UploadEndpointTest.java
@@ -407,8 +407,6 @@ class UploadEndpointTest {
 
     @Test
     void uploadMalformedGzipCompressedData() {
-        // Test that malformed gzip-compressed payloads return a client error (400)
-        // rather than a server error (500)
         byte[] invalidGzipPayload = "not-a-valid-gzip-stream".getBytes(StandardCharsets.UTF_8);
 
         given()


### PR DESCRIPTION
## Summary

Sync upstream `trustyai-explainability/trustyai-explainability:main` into downstream `red-hat-data-services/trustyai-explainability:rhoai-3.5-ea.2`.

Includes recent upstream changes notably:
- PR #707 — Fix gzip decompression for all inbound endpoints
- PR #708 — Guard against null CloudEvent data buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)