### PR TITLE
fix: Bump Netty to 4.1.136.Final + Parsson to 1.1.9 (11 CVEs)

### DIFF
--- a/explainability-connectors/pom.xml
+++ b/explainability-connectors/pom.xml
@@ -28,78 +28,78 @@
                 <artifactId>protobuf-java</artifactId>
                 <version>3.25.5</version>
             </dependency>
-            <!-- Override the version of  io.netty:netty-handler -->
+            <!-- Override io.netty version to address CVEs -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             
             <!-- Force all Netty modules to use the same version -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-common</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-buffer</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-unix-common</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler-proxy</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http2</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-socks</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver-dns</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-dns</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-haproxy</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/explainability-service/pom.xml
+++ b/explainability-service/pom.xml
@@ -44,78 +44,78 @@
             <artifactId>xstream</artifactId>
             <version>1.4.21</version>
           </dependency>
-          <!-- Override to io.netty:netty-handler:4.1.125.Final -->
+          <!-- Override io.netty version to address CVEs -->
           <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.125.Final</version>
+            <version>${version.io.netty}</version>
           </dependency>
           
           <!-- Force all Netty modules to use the same version -->
           <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-            <version>4.1.125.Final</version>
+            <version>${version.io.netty}</version>
           </dependency>
           <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>4.1.125.Final</version>
+            <version>${version.io.netty}</version>
           </dependency>
           <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
-            <version>4.1.125.Final</version>
+            <version>${version.io.netty}</version>
           </dependency>
           <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <version>4.1.125.Final</version>
+            <version>${version.io.netty}</version>
           </dependency>
           <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver</artifactId>
-            <version>4.1.125.Final</version>
+            <version>${version.io.netty}</version>
           </dependency>
                       <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-unix-common</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler-proxy</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http2</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-socks</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver-dns</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-dns</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-haproxy</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/explainability-service/pom.xml
+++ b/explainability-service/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>xstream</artifactId>
             <version>1.4.21</version>
           </dependency>
+          <dependency>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+            <version>${version.org.eclipse.parsson}</version>
+          </dependency>
           <!-- Override io.netty version to address CVEs -->
           <dependency>
             <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,8 @@
         <formatter.plugin.version>2.13.0</formatter.plugin.version>
         <impsort.plugin.version>1.9.0</impsort.plugin.version>
 
-        <version.io.netty>4.1.133.Final</version.io.netty>
+        <version.io.netty>4.1.136.Final</version.io.netty>
+        <version.org.eclipse.parsson>1.1.9</version.org.eclipse.parsson>
         <nexus.staging.plugin.version>1.6.6</nexus.staging.plugin.version>
 
         <formatter.skip>false</formatter.skip>
@@ -100,6 +101,12 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${version.com.fasterxml.jackson.databind}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.parsson</groupId>
+                <artifactId>parsson</artifactId>
+                <version>${version.org.eclipse.parsson}</version>
             </dependency>
 
             <!-- Override the version of  io.netty:netty-handler -->

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <formatter.plugin.version>2.13.0</formatter.plugin.version>
         <impsort.plugin.version>1.9.0</impsort.plugin.version>
 
-        <version.io.netty>4.1.125.Final</version.io.netty>
+        <version.io.netty>4.1.133.Final</version.io.netty>
         <nexus.staging.plugin.version>1.6.6</nexus.staging.plugin.version>
 
         <formatter.skip>false</formatter.skip>
@@ -106,74 +106,74 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             
             <!-- Force all Netty modules to use the same version -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-common</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-buffer</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-unix-common</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler-proxy</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http2</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-socks</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver-dns</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-dns</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-haproxy</artifactId>
-                <version>4.1.125.Final</version>
+                <version>${version.io.netty}</version>
             </dependency>
 
             <!-- TEST dependencies -->


### PR DESCRIPTION
## Summary

Bumps Netty and Eclipse Parsson to fix **11 CVEs** against `odh-trustyai-service-rhel9` on `rhoai-3.4`.

### Netty 4.1.125.Final → 4.1.136.Final (10 CVEs)

| CVE | Vulnerability |
|-----|---------------|
| CVE-2026-42583 | DoS via LZ4FrameDecoder memory allocation |
| CVE-2026-42587 | DoS via HTTP content decompression bypass |
| CVE-2026-42578 | HTTP Header Injection via HttpProxyHandler |
| CVE-2026-42581 | HTTP Request Smuggling (HTTP/1.0 headers) |
| CVE-2026-42584 | Incorrect HTTP response parsing |
| CVE-2026-42579 | Improper DNS domain name constraint enforcement |
| CVE-2026-47691 | DNS cache poisoning via NS bailiwick |
| CVE-2026-50010 | Hostname verification bypass |
| CVE-2026-45674 | CNAME record validation bypass |
| CVE-2026-45416 | TLS handshake DoS |

### Eclipse Parsson 1.1.5 → 1.1.9 (1 CVE)

| CVE | Vulnerability |
|-----|---------------|
| CVE-2026-9563 | JSON parsing DoS |

## Changes

- `pom.xml`: `version.io.netty` → `4.1.136.Final`, added `version.org.eclipse.parsson` = `1.1.9`
- `explainability-service/pom.xml`: added Parsson override in `dependencyManagement`
- `explainability-connectors/pom.xml`: Netty versions already use `${version.io.netty}` (no change needed)
- All hardcoded Netty versions replaced with `${version.io.netty}` property references

## Test plan

- [x] Konflux build passes on all 4 architectures (x86_64, aarch64, ppc64le, s390x)
- [x] `mvn dependency:tree` confirms Netty 4.1.136.Final and Parsson 1.1.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)