### PR TITLE
fix: Bump Jackson-databind to 2.18.9 (CVE-2026-54512)

### DIFF
--- a/explainability-service/pom.xml
+++ b/explainability-service/pom.xml
@@ -44,6 +44,22 @@
             <artifactId>xstream</artifactId>
             <version>1.4.21</version>
           </dependency>
+          <!-- Override Jackson to address CVE-2026-54512 -->
+          <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${version.com.fasterxml.jackson}</version>
+          </dependency>
+          <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${version.com.fasterxml.jackson}</version>
+          </dependency>
+          <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${version.com.fasterxml.jackson}</version>
+          </dependency>
           <!-- Override to io.netty:netty-handler:4.1.125.Final -->
           <dependency>
             <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <maven.compiler.target>17</maven.compiler.target>
 
         <version.org.slf4j>1.7.36</version.org.slf4j>
-        <version.com.fasterxml.jackson.databind>2.15.0</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson>2.18.9</version.com.fasterxml.jackson>
         <version.org.apache.commons.commons-lang3>3.18.0</version.org.apache.commons.commons-lang3>
         <version.org.apache.commons.commons-csv>1.9.0</version.org.apache.commons.commons-csv>
         <version.org.apache.opennlp>1.9.2</version.org.apache.opennlp>
@@ -99,7 +99,17 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${version.com.fasterxml.jackson.databind}</version>
+                <version>${version.com.fasterxml.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${version.com.fasterxml.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${version.com.fasterxml.jackson}</version>
             </dependency>
 
             <!-- Override the version of  io.netty:netty-handler -->


### PR DESCRIPTION
## Summary

Bumps Jackson from **2.15.0** to **2.18.9** (LTS) to fix CVE-2026-54512 and align all Jackson modules.

| CVE | Vulnerability |
|-----|---------------|
| CVE-2026-54512 | **RCE** via PolymorphicTypeValidator bypass (CVSS 8.1) |
| CVE-2026-50193 | DoS via nested JSON — **VEX: already fixed** in >= 2.14.0 |

## Changes

- `pom.xml`: renamed property `version.com.fasterxml.jackson.databind` → `version.com.fasterxml.jackson` = `2.18.9`, added `jackson-core` and `jackson-annotations` to `dependencyManagement`
- `explainability-service/pom.xml`: added Jackson overrides in `dependencyManagement` to override Quarkus BOM

## Risk assessment

This is a **moderate-risk** change:
- Jackson 2.15.0 → 2.18.9 spans 3 minor versions
- The existing setup already had a version mismatch (databind 2.15.0 vs core/annotations 2.17.0 from Quarkus BOM) — this PR fixes that by aligning all three at 2.18.9
- Locally verified: `mvn compile` passes cleanly on all modules (core, connectors, service)
- Jackson 2.18.x is the first LTS branch — supported through at least 2026

## Test plan

- [x] Konflux build passes on all 4 architectures
- [x] `mvn dependency:tree` confirms all Jackson modules at 2.18.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)